### PR TITLE
fix: preserve versioned CDN uploads

### DIFF
--- a/.github/workflows/upload-cdn-files.yaml
+++ b/.github/workflows/upload-cdn-files.yaml
@@ -82,17 +82,30 @@ jobs:
           CONTRACTS_VERSION_OVERRIDE: ${{ inputs.contracts_version }}
         working-directory: packages/contracts-cdn
         run: |
-          version="${CONTRACTS_VERSION_OVERRIDE:-$(jq '.version' ../contracts/package.json -r)}"
+          version="$(printf '%s' "${CONTRACTS_VERSION_OVERRIDE:-}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          version="${version:-$(jq '.version' ../contracts/package.json -r)}"
 
           echo "Uploading contract-cache version v${version} to R2 bucket ${R2_BUCKET_CACHE}..."
 
-          rclone sync tmp/contract-cache "r2:${R2_BUCKET_CACHE}/contract-cache" \
-            --config ./rclone.conf \
-            --checksum \
-            --fast-list \
-            --transfers 16 \
-            --checkers 32 \
-            --exclude "/**/temp_diff/**"
+          for network in mina:devnet mina:mainnet; do
+            source_dir="tmp/contract-cache/${network}/v${version}"
+            manifest_path="${source_dir}/manifest.json"
+
+            if [ ! -f "${manifest_path}" ]; then
+              echo "Expected manifest not found: ${manifest_path}"
+              exit 1
+            fi
+
+            echo "Uploading ${source_dir} to contract-cache/${network}/v${version}..."
+
+            rclone copy "${source_dir}" "r2:${R2_BUCKET_CACHE}/contract-cache/${network}/v${version}" \
+              --config ./rclone.conf \
+              --checksum \
+              --fast-list \
+              --transfers 16 \
+              --checkers 32 \
+              --exclude "/temp_diff/**"
+          done
 
   deploy-cdn:
     name: Deploy CDN Worker

--- a/packages/contracts-cdn/scripts/create-cache.ts
+++ b/packages/contracts-cdn/scripts/create-cache.ts
@@ -9,7 +9,7 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname)
 const network = (process.argv[2] ?? "mina:devnet") as (typeof networks)[number]
 const isValidNetwork = networks.includes(network)
 if (!isValidNetwork) throw new Error(`Invalid network argument. Expected one of: ${networks.join(", ")}`)
-const version = process.argv[3] ?? process.env.CONTRACTS_VERSION_OVERRIDE ?? defaultVersion
+const version = process.argv[3]?.trim() || process.env.CONTRACTS_VERSION_OVERRIDE?.trim() || defaultVersion
 
 // Cache directory per network
 export const cacheDir = path.resolve(__dirname, `../cache/${network}`)

--- a/packages/contracts-cdn/scripts/validate-bundle.ts
+++ b/packages/contracts-cdn/scripts/validate-bundle.ts
@@ -10,7 +10,7 @@ const network = (process.argv[2] ?? "mina:devnet") as (typeof networks)[number]
 const isValidNetwork = networks.includes(network)
 if (!isValidNetwork) throw new Error(`Invalid network argument. Expected one of: ${networks.join(", ")}`)
 
-const version = process.argv[3] ?? process.env.CONTRACTS_VERSION_OVERRIDE ?? defaultVersion
+const version = process.argv[3]?.trim() || process.env.CONTRACTS_VERSION_OVERRIDE?.trim() || defaultVersion
 const bundlePath = path.resolve(__dirname, `../tmp/contract-cache/${network}/v${version}/bundle.zip`)
 
 const bundle = await fs.readFile(bundlePath)


### PR DESCRIPTION
## Summary
- treat empty `contracts_version` inputs as unset in the CDN cache scripts
- upload only the requested version directories to R2 instead of syncing the whole `contract-cache` tree
- fail the upload step early if the expected versioned manifests were not built

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/upload-cdn-files.yaml"); puts "yaml ok"'`
- `CONTRACTS_VERSION_OVERRIDE='' moon run contracts-cdn:build-cache` reached `Creating cache for mina:devnet - version v0.10.0` and `uploadBaseDir: .../v0.10.0`
- `node --experimental-strip-types packages/contracts-cdn/scripts/create-cache.ts mina:devnet ''` resolved to `version v0.10.0` and `uploadBaseDir .../v0.10.0`

## Incident addressed
- avoids publishing to `contract-cache/<network>/v/...` when the manual workflow input is left blank
- avoids deleting previously published versions by replacing broad `rclone sync tmp/contract-cache ...` with per-version `rclone copy` uploads
